### PR TITLE
Bugfix/orb extractor crash

### DIFF
--- a/src/ORBextractor.cc
+++ b/src/ORBextractor.cc
@@ -541,8 +541,7 @@ vector<cv::KeyPoint> ORBextractor::DistributeOctTree(const vector<cv::KeyPoint>&
                                        const int &maxX, const int &minY, const int &maxY, const int &N, const int &level)
 {
     // Compute how many initial nodes   
-    const int nIni = round(static_cast<float>(maxX-minX)/(maxY-minY));
-
+	const auto nIni = std::max(1,(int)round(static_cast<float>(maxX-minX)/(maxY-minY)));
     const float hX = static_cast<float>(maxX-minX)/nIni;
 
     list<ExtractorNode> lNodes;


### PR DESCRIPTION
If Image width is less than Image height, the it was crashed in ORBextractor::DistributeOctTree.
To fix this issue, use the following code
const auto nIni = std::max(1,(int)round(static_cast(maxX-minX)/(maxY-minY)));