### PR TITLE
Feature/#44 orbslam2 win dependant bin

### DIFF
--- a/scripts/windows/bootstrap.bat
+++ b/scripts/windows/bootstrap.bat
@@ -2,42 +2,63 @@
 
 set "OrbSlamPlatform=x86"
 set "OrbSlamToolset=v141"
-set "OrbSlamBuildType=Release"
 
 if NOT "%~1"=="" set "OrbSlamPlatform=%~1"
 if NOT "%~2"=="" set "OrbSlamToolset=%~2"
-if NOT "%~3"=="" set "OrbSlamBuildType=%~3" 
 
-set "VcPkgDir=%~d0\Software\vcpkg\vcpkg"
-
-if not exist "%VcPkgDir%" (
-    git clone --recursive https://github.com/paul-michalik/vcpkg.git "%VcPkgDir%"
-) else (
-    cd /d "%VcPkgDir%"
-    git pull --all --prune
-)
-
-call "%VcPkgDir%"\bootstrap-vcpkg.bat
+set "VcPkgGitUrl=https://github.com/apattnaik0721013/vcpkg.git"
+set "VcPkgTag=0.0.81-6"
+set "VcPkgDir=%~d0\Software\vcpkg\vcpkg-%VcPkgTag%"
 
 if defined VCPKG_ROOT_DIR if /i not "%VCPKG_ROOT_DIR%"=="" set "VcPkgDir=%VCPKG_ROOT_DIR%"
 set "VcPkgTriplet=%OrbSlamPlatform%-windows-%OrbSlamToolset%"
 if defined VCPKG_DEFAULT_TRIPLET if /i not "%VCPKG_DEFAULT_TRIPLET%"=="" set "VcpkgTriplet=%VCPKG_DEFAULT_TRIPLET%"
-set "VcPkgPath=%VcPkgDir%\vcpkg.exe"
+set "VcPkgBinPath=%VcPkgDir%\Conan4Vcpkg.bat"
 
-echo. & echo Bootstrapping dependencies for triplet: %VcPkgTriplet% & echo.
 
-if not exist "%VcPkgDir%" echo vcpkg path is not set correctly, bailing out & exit /b 1
+echo. & echo Installing/updating vcpkg...
+call :BootstrapVcPkg "%VcPkgGitUrl%" "%VcPkgTag%" "%VcPkgDir%"
+if %errorlevel% neq 0 echo An error occured in %~n0, bailing out & exit /b %errorlevel%
+echo. & echo vcpkg %VcPkgTag% successfully installed...
 
 rem ==============================
 rem Update and Install packages.
 rem ==============================
-call "%VcPkgPath%" update
-call "%VcPkgPath%" install eigen3 opencv pangolin --triplet %VcPkgTriplet%
 
-set "VcPkgTripletDir=%VcPkgDir%\installed\%VcPkgTriplet%"
+call "%VcPkgBinPath%" consumer "eigen3 opencv pangolin" %OrbSlamPlatform% %OrbSlamToolset%
 
+set "VcPkgTripletDir=%VcPkgDir%\download_vcpkg_binary\installed\%VcPkgTriplet%"
 if not exist "%VcPkgTripletDir%" echo %VcPkgTripletDir% does not exist, bailing out & exit /b 1
 
 set "CMAKE_PREFIX_PATH=%VcPkgTripletDir%;%CMAKE_PREFIX_PATH%"
 
 echo. & echo Bootstrapping successful for triplet: %VcPkgTriplet% & echo CMAKE_PREFIX_PATH=%CMAKE_PREFIX_PATH% & echo.
+
+goto :eof
+
+:BootstrapVcPkg
+setlocal
+    set "LocErrorState=0"
+    set "LocVcPkgGit=%~1"
+    set "LocVcPkgTag=%~2"
+    set "LocVcPkgDir=%~3"
+    set "LocVcPkgTag=tags/%LocVcPkgTag%"
+
+    echo Checking for existence of "%LocVcPkgDir%"...
+    if not exist "%LocVcPkgDir%" (
+        echo Attempt to: git clone "%LocVcPkgGit%" "%LocVcPkgDir%"...
+        git clone "%LocVcPkgGit%" "%LocVcPkgDir%"
+    )
+    if %errorlevel% neq 0 echo An error occured in %~n0, bailing out & exit /b %errorlevel%
+
+    pushd "%LocVcPkgDir%"
+    if %errorlevel% neq 0 echo An error occured in %~n0, bailing out & exit /b %errorlevel%
+
+    echo Attempt to: git fetch --all --tags --prune...
+    git fetch --all --tags --prune
+    if %errorlevel% neq 0 echo An error occured in %~n0, bailing out & exit /b %errorlevel
+
+    popd
+endlocal & exit /b %errorlevel%
+
+goto :eof

--- a/scripts/windows/bootstrap.bat
+++ b/scripts/windows/bootstrap.bat
@@ -1,33 +1,34 @@
 @echo off
 
-set "OrbSlamPlatform=x86"
+set "OrbSlamPlatform=x64"
 set "OrbSlamToolset=v141"
 
 if NOT "%~1"=="" set "OrbSlamPlatform=%~1"
 if NOT "%~2"=="" set "OrbSlamToolset=%~2"
 
-set "VcPkgGitUrl=https://github.com/apattnaik0721013/vcpkg.git"
-set "VcPkgTag=0.0.81-6"
-set "VcPkgDir=%~d0\Software\vcpkg\vcpkg-%VcPkgTag%"
+set "VcPkgGitUrl=https://github.com/apattnaik0721013/conan4vcpkg.git"
+set "VcPkgDir=%~d0\Software\vcpkgbin"
 
 if defined VCPKG_ROOT_DIR if /i not "%VCPKG_ROOT_DIR%"=="" set "VcPkgDir=%VCPKG_ROOT_DIR%"
 set "VcPkgTriplet=%OrbSlamPlatform%-windows-%OrbSlamToolset%"
 if defined VCPKG_DEFAULT_TRIPLET if /i not "%VCPKG_DEFAULT_TRIPLET%"=="" set "VcpkgTriplet=%VCPKG_DEFAULT_TRIPLET%"
-set "VcPkgBinPath=%VcPkgDir%\Conan4Vcpkg.bat"
-
+set "VcPkgBinPath=%VcPkgDir%\vcpkgbin.bat"
 
 echo. & echo Installing/updating vcpkg...
-call :BootstrapVcPkg "%VcPkgGitUrl%" "%VcPkgTag%" "%VcPkgDir%"
+call :BootstrapVcPkg "%VcPkgGitUrl%" "%VcPkgDir%"
 if %errorlevel% neq 0 echo An error occured in %~n0, bailing out & exit /b %errorlevel%
 echo. & echo vcpkg %VcPkgTag% successfully installed...
 
 rem ==============================
 rem Update and Install packages.
 rem ==============================
+set "cur_path=%~dp0"
+cd %VcPkgDir%
+call "%VcPkgBinPath%" download vcpkg/0.0.81-6@had/vcpkg "eigen3 opencv pangolin" %VcPkgTriplet%
+if %errorlevel% neq 0 echo An error occured in %~n0, bailing out & exit /b %errorlevel%
+cd %cur_path%
 
-call "%VcPkgBinPath%" consumer "eigen3 opencv pangolin" %OrbSlamPlatform% %OrbSlamToolset%
-
-set "VcPkgTripletDir=%VcPkgDir%\download_vcpkg_binary\installed\%VcPkgTriplet%"
+set "VcPkgTripletDir=%VcPkgDir%\installed\%VcPkgTriplet%"
 if not exist "%VcPkgTripletDir%" echo %VcPkgTripletDir% does not exist, bailing out & exit /b 1
 
 set "CMAKE_PREFIX_PATH=%VcPkgTripletDir%;%CMAKE_PREFIX_PATH%"
@@ -40,9 +41,7 @@ goto :eof
 setlocal
     set "LocErrorState=0"
     set "LocVcPkgGit=%~1"
-    set "LocVcPkgTag=%~2"
-    set "LocVcPkgDir=%~3"
-    set "LocVcPkgTag=tags/%LocVcPkgTag%"
+    set "LocVcPkgDir=%~2"
 
     echo Checking for existence of "%LocVcPkgDir%"...
     if not exist "%LocVcPkgDir%" (

--- a/scripts/windows/build.bat
+++ b/scripts/windows/build.bat
@@ -2,9 +2,9 @@
 
 setlocal
 
-set "OrbSlamPlatform=x86"
+set "OrbSlamPlatform=x64"
 set "OrbSlamToolset=v141"
-set "OrbSlamBuildType=Debug"
+set "OrbSlamBuildType=Release"
 
 if NOT "%~1"=="" set "OrbSlamPlatform=%~1"
 if NOT "%~2"=="" set "OrbSlamToolset=%~2"
@@ -25,7 +25,7 @@ if "%OrbSlamPlatform%"=="x64" (
     if "%OrbSlamToolset%"=="v141" set "OrbSlamCMakeGeneratorName=Visual Studio 15 2017 Win64"
 )
 
-set "OrbSlamBuildDir=%~dp0..\..\products\cmake.msbuild.windows.%OrbSlamPlatform%.%OrbSlamToolset%"
+set "OrbSlamBuildDir=%~dp0..\..\products\cmake.msbuild.windows.%OrbSlamPlatform%.%OrbSlamToolset%.%OrbSlamBuildType%"
 if not exist "%OrbSlamBuildDir%" mkdir "%OrbSlamBuildDir%"
 cd "%OrbSlamBuildDir%"
 

--- a/scripts/windows/build.bat
+++ b/scripts/windows/build.bat
@@ -10,11 +10,8 @@ if NOT "%~1"=="" set "OrbSlamPlatform=%~1"
 if NOT "%~2"=="" set "OrbSlamToolset=%~2"
 if NOT "%~3"=="" set "OrbSlamBuildType=%~3" 
 
-set "VcPkgDir=%~d0\Software\vcpkg\vcpkg"
-set "VcPkgTriplet=%OrbSlamPlatform%-windows-%OrbSlamToolset%"
-set "VcPkgTripletDir=%VcPkgDir%\installed\%VcPkgTriplet%"
-if not exist "%VcPkgTripletDir%" echo %VcPkgTripletDir% does not exist, bailing out & exit /b 1
-set "CMAKE_PREFIX_PATH=%VcPkgTripletDir%;%CMAKE_PREFIX_PATH%"
+call "%~dp0bootstrap.bat" %*
+if %errorlevel% neq 0 echo An error occured in %~n0, bailing out & exit /b %errorlevel%
 
 set "OrbSlamCMakeGeneratorName=Visual Studio 14 2015"
 

--- a/scripts/windows/run_slam_on_garching_test_drive.bat
+++ b/scripts/windows/run_slam_on_garching_test_drive.bat
@@ -1,10 +1,19 @@
 @echo off
 
 setlocal
-set "VcpkgBinDir=%~d0\Software\vcpkg\vcpkg\installed\x86-windows-v141\bin"
+set "OrbSlamPlatform=x64"
+set "OrbSlamToolset=v141"
+set "OrbSlamBuildType=Release"
+
+if NOT "%~1"=="" set "OrbSlamPlatform=%~1"
+if NOT "%~2"=="" set "OrbSlamToolset=%~2"
+
+set "VcPkgTriplet=%OrbSlamPlatform%-windows-%OrbSlamToolset%"
+set "VcpkgBinDir=%~d0\Software\vcpkgbin\installed\%VcPkgTriplet%\bin"
+echo "%VcpkgBinDir%"
 set "ProjectDir=%~dp0..\.."
-set "Path=%Path%;%VcpkgBinDir%;C:\Program Files\7-Zip"
-set "OrbSlam2ProductsDir=%ProjectDir%\products\cmake.msbuild.windows.x86.v141"
+set "Path=%VcpkgBinDir%;C:\Program Files\7-Zip;%Path%"
+set "OrbSlam2ProductsDir=%ProjectDir%\products\cmake.msbuild.windows.%OrbSlamPlatform%.%OrbSlamToolset%.%OrbSlamBuildType%"
 
 cd %ProjectDir%
 


### PR DESCRIPTION
Add support of vcpkg binary support in orb-slam2.
currently binary of https://github.com/apattnaik0721013/vcpkg is taken.
latter we can merge to your branch if it sounds good.
To build this orb-slam2, 
     go to ORB_SLAM2\scripts\windows
     run build.bat <platform> <toolset> <buildtype>
     currently it was tested with 
      build.bat x64 v141 Release